### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/gm-toolset/e77dd1d5-dbcd-4c3e-9ec7-8861c437d194/e6f60ae7-b250-4c9a-be65-6968fb042cd1/_apis/work/boardbadge/ed5ac088-6f57-4033-bb44-f86968153594)](https://dev.azure.com/gm-toolset/e77dd1d5-dbcd-4c3e-9ec7-8861c437d194/_boards/board/t/e6f60ae7-b250-4c9a-be65-6968fb042cd1/Microsoft.RequirementCategory)
 # GM-Toolset


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/gm-toolset/e77dd1d5-dbcd-4c3e-9ec7-8861c437d194/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.